### PR TITLE
Add temperature and powerUsage per device

### DIFF
--- a/custom_components/nicehash/sensor.py
+++ b/custom_components/nicehash/sensor.py
@@ -405,6 +405,8 @@ class NiceHashDeviceStatSensor(NiceHashSensor):
         dev = self.get_device()
         if dev is not None:
             state = dev.get(self._info_type)
+            if self._info_type == "temperature" and state > 500:
+                return state % 65536
             if state is not -1:
                 return state
         return None


### PR DESCRIPTION
Hello, excellent integration! 

I agreed with #9, in that some device stats would be useful. This PR adds a sensor for each device's `temperature` and `powerUsage`. What are your thoughts on the feature? 

There's a small annoyance, where if the HA instance is set to Imperial units, the temerature is converted to `°F`  - do you know if it's possible to force `°C`?

![Screenshot from 2021-03-25 16-00-27](https://user-images.githubusercontent.com/1429672/112554565-ce853280-8d83-11eb-9b86-f4d4d666fc6b.png)

Fixes #9 