### PR TITLE
fiatRate is present in API response only if wallet has had a payout

### DIFF
--- a/custom_components/nicehash/sensor.py
+++ b/custom_components/nicehash/sensor.py
@@ -165,7 +165,7 @@ class NiceHashGlobalSensor(CoordinatorEntity, Entity):
         if self._convert and self._info.get("unit", None) == "BTC":
             return (
                 float(self.coordinator.data[self._data_type][self._info_type])
-                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0]["fiatRate"]
+                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0].get("fiatRate",0)
             )
         return self.coordinator.data[self._data_type][self._info_type]
 
@@ -275,7 +275,7 @@ class NiceHashRigSensor(NiceHashSensor):
         if self._convert and self._info.get("unit", None) == "BTC":
             return (
                 self.get_rig()[self._info_type]
-                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0]["fiatRate"]
+                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0].get("fiatRate",0)
             )
         return self.get_rig()[self._info_type]
 
@@ -329,7 +329,7 @@ class NiceHashRigStatSensor(NiceHashSensor):
             if self._convert:
                 return (
                     alg.get(self._info_type)
-                    * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0]["fiatRate"]
+                    * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0].get("fiatRate",0)
                 )
             return alg.get(self._info_type)
         return None
@@ -376,6 +376,6 @@ class NiceHashAccountGlobalSensor(NiceHashGlobalSensor):
                         self._info_type
                     ]
                 )
-                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0]["fiatRate"]
+                * self.coordinator.data[ACCOUNT_OBJ]["currencies"][0].get("fiatRate",0)
             )
-        return self.coordinator.data[self._data_type]["currencies"][0][self._info_type]
+        return self.coordinator.data[self._data_type]["currencies"][0].get(self._info_type,0)


### PR DESCRIPTION
as confirmed by nicehash support, the fiatRate item in present in api response only if you have btc in your wallet.
Fixes https://github.com/RomRider/ha_nicehash/issues/26#issuecomment-1490234923